### PR TITLE
RFC: open generated factory for further editing

### DIFF
--- a/src/cz/jiripudil/intellij/nette/factoryGenerator/ui/GenerateFactoryInterfaceDialog.form
+++ b/src/cz/jiripudil/intellij/nette/factoryGenerator/ui/GenerateFactoryInterfaceDialog.form
@@ -16,11 +16,6 @@
         <properties/>
         <border type="none"/>
         <children>
-          <hspacer id="98af6">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
           <grid id="9538f" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="true" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
@@ -47,6 +42,15 @@
               </component>
             </children>
           </grid>
+          <component id="6934d" class="javax.swing.JCheckBox" binding="openFile">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="true"/>
+              <text value="Open &amp;generated factory"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <grid id="e3588" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/cz/jiripudil/intellij/nette/factoryGenerator/ui/GenerateFactoryInterfaceDialog.java
+++ b/src/cz/jiripudil/intellij/nette/factoryGenerator/ui/GenerateFactoryInterfaceDialog.java
@@ -2,6 +2,8 @@ package cz.jiripudil.intellij.nette.factoryGenerator.ui;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.CollectionListModel;
@@ -25,6 +27,7 @@ public class GenerateFactoryInterfaceDialog extends JDialog {
     private JButton buttonCancel;
     private JBTextField interfaceName;
     private JBList<ConstructorParameter> factoryParams;
+    private JCheckBox openFile;
 
     @NotNull private Project project;
     @Nullable private PsiFile psiFile;
@@ -99,7 +102,12 @@ public class GenerateFactoryInterfaceDialog extends JDialog {
         }
 
         FactoryInterfaceGenerator generator = ApplicationManager.getApplication().getComponent(FactoryInterfaceGenerator.class);
-        generator.generateFactory(project, psiFile, originalClass, name, parameters);
+        PsiFile file = generator.generateFactory(project, psiFile, originalClass, name, parameters);
+
+        if (openFile.isSelected()) {
+            OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file.getVirtualFile());
+            FileEditorManager.getInstance(project).openEditor(descriptor, true);
+        }
 
         dispose();
     }


### PR DESCRIPTION
It feels kinda strange that once the factory is generated, it is not opened in the editor. You cannot check it visually and with some settings (hidden files pane, git auto-add, etc.), you might not even get any indication that it has been generated. So I implemented it, in just two lines of code. But...

This plugin has been out in the wild for some time and has over seven hundred downloads, and I have no clue how people use it. I imagine this change might be a BC break for some. So I came up with a checkbox in the generator dialog:

<img width="558" alt="snimek obrazovky 2017-04-22 v 13 22 46" src="https://cloud.githubusercontent.com/assets/1042159/25304016/dce715da-275e-11e7-9bad-eb0cfa22892a.png">

I'm not sure about it either: It is checked by default, which is still one additional click for people who don't need to check the generated factory.

---

So I am calling out for comments: How do you use the plugin? Do you check the factory after it's generated, or do you trust the generator? How would you like this PR resolved? Please vote by adding reactions so I have some quantitative answers:

- ❤️ = "I don't need no checkbox, just open the factory every time."
- 👍 = "The checkbox is cool and you can leave it checked by default."
- 👎 = "The checkbox is cool, but would be cooler if it was unchecked by default."
- 😕 = "I don't like any of this 💩, please just leave it as it is and close this PR."

Thanks a lot!